### PR TITLE
Set latest ch.js version as 2023-01-31

### DIFF
--- a/docs/chargify.js/Version-History.md
+++ b/docs/chargify.js/Version-History.md
@@ -25,7 +25,11 @@ integration, or implement a Content Security Policy (CSP).  Example:
 ❗️ We will support previous releases of Chargify.js for a maximum time frame of 6 months. If you use an explicitly versioned path of Chargify.js, you must commit to updating your integration regularly.  Versions older than 6 months will be unsupported and may be removed without notice.
 
 ## Release History
-* **2022-12-05** **latest**
+* **2023-01-31** **latest**
+  * [internal] fix source maps generation
+* **2023-01-26**
+  * [internal] upgrade to node 16
+* **2022-12-05**
   * [internal] Initial support for payments service
 * **2022-11-30** 
   * [feature] add ability to listen to the address change event


### PR DESCRIPTION
- adds ch.js version 2023-01-26  "[internal] upgrade to node 16"
- sets latest ch.js version as 2023-01-31 "[internal] fix source maps generation"