### PR TITLE
set the latest Chargify.js version to 2023-02-06

### DIFF
--- a/docs/chargify.js/Version-History.md
+++ b/docs/chargify.js/Version-History.md
@@ -25,7 +25,9 @@ integration, or implement a Content Security Policy (CSP).  Example:
 ❗️ We will support previous releases of Chargify.js for a maximum time frame of 6 months. If you use an explicitly versioned path of Chargify.js, you must commit to updating your integration regularly.  Versions older than 6 months will be unsupported and may be removed without notice.
 
 ## Release History
-* **2023-02-02** **latest**
+* **2023-02-06** **latest**
+  * [bugfix] fix validation for default values
+* **2023-02-02**
   * [internal] improve ACH flow
 * **2023-01-31**
   * [internal] fix source maps generation


### PR DESCRIPTION
Related PR: https://github.com/maxio-com/chargify-js/pull/165

#### What?
[bugfix] fix validation for default values