### PR TITLE
Update API-Code-Samples.md

### DIFF
--- a/docs/ecosystem/API-Code-Samples.md
+++ b/docs/ecosystem/API-Code-Samples.md
@@ -12,13 +12,13 @@ If you have usage examples or code libraries in other languages, please let us k
 
 Maxio offers Advanced Billing SDKs to support the following community tech stacks: 
  
- + [Python](https://pypi.org/project/maxio-advanced-billing-sdk/1.0.0/)
- + [Ruby](https://rubygems.org/gems/maxio-advanced-billing-sdk/versions/1.0.0)
+ + [Python](https://pypi.org/project/maxio-advanced-billing-sdk/)
+ + [Ruby](https://rubygems.org/gems/maxio-advanced-billing-sdk/)
  + [PHP](https://packagist.org/packages/maxio/advanced-billing-sdk)
- + [C#/.NET](https://www.nuget.org/packages/Maxio.AdvancedBillingSdk/1.0.0)
- + [Typescript](https://www.npmjs.com/package/@maxio-com/advanced-billing-sdk/v/1.0.0)
+ + [C#/.NET](https://www.nuget.org/packages/Maxio.AdvancedBillingSdk/)
+ + [Typescript](https://www.npmjs.com/package/@maxio-com/advanced-billing-sdk/)
  + [Java](https://central.sonatype.com/artifact/com.maxio/advanced-billing-sdk)
- + [Go(Alpha)](https://pkg.go.dev/github.com/maxio-com/ab-golang-sdk@v1.0.0-alpha.1)
+ + [Go](https://pkg.go.dev/github.com/maxio-com/ab-golang-sdk@v0.1.0)
  
 
 ## Community-managed SDKs


### PR DESCRIPTION
- Removed version numbers from URLs, except for GO, which has version number hardcoded in URL.
- Tested URLs to make sure "generic" URL pointed to the latest SDK version (which in this case is 2.0)
- Removed "Alpha" from Go link (beta was released today, 3/21/24)