### PR TITLE
[documentation] Add docs to creditCardExpirationDateDropdowns field

### DIFF
--- a/docs/chargify.js/Chargify.js-Configurations.md
+++ b/docs/chargify.js/Chargify.js-Configurations.md
@@ -52,6 +52,7 @@ chargify.load({
 
     // Use auto-populated dropdowns instead of plain text fields
     addressDropdowns: true,
+    creditCardExpirationDateDropdowns: true,
 
     // optional unless your site uses multi-currency with BlueSnap gateway
     currency: 'USD,
@@ -509,6 +510,7 @@ Returned card types: `american-express`, `diners`, `diners-club`, `discover`, `j
 | selectorForPayPalButton | `#pay-pal` | Required for PayPal | The selector for the PayPal button. |
 | deviceData | `true` | Required to use Braintree Advanced Fraud Protection feature | Enables collecting Device Data information as part of the Braintree Advanced Fraud Protection feature. |
 | addressDropdowns | `true` | Optional, not supported for GoCardless | Renders country and state fields as dropdowns instead of plain text fields. |
+| creditCardExpirationDateDropdowns | `true` | Optional, not supported for GoCardless | Renders credit card expiration month and year as dropdowns instead of plain text fields. |
 | currency | `USD` | Optional | Choose which currency do you want to use. You should set this when your site uses multi-currency and BlueSnap as the gateway or when you site uses multi-currency and you use Stripe gateway for Direct Debit. |
 
 

--- a/docs/chargify.js/Version-History.md
+++ b/docs/chargify.js/Version-History.md
@@ -25,7 +25,9 @@ integration, or implement a Content Security Policy (CSP).  Example:
 ❗️ We will support previous releases of Chargify.js for a maximum time frame of 6 months. If you use an explicitly versioned path of Chargify.js, you must commit to updating your integration regularly.  Versions older than 6 months will be unsupported and may be removed without notice.
 
 ## Release History
-* **2024-05-23** **latest**
+* **2024-06-10** **latest**
+  * [feature] Add possibility to set credit card expiration date fields as dropdowns
+* **2024-05-23**
   * [feature] GoCardless ACH Integration 
 * **2024-04-30** 
   * [bugfix] Fix ApplePay payment method


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration option to render credit card expiration month and year as dropdowns in the `Chargify.js` library.

- **Documentation**
  - Updated configuration documentation to include the new `creditCardExpirationDateDropdowns` option.
  - Added the latest feature to the version history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->